### PR TITLE
Multiaddr Update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.1.0")),
+        .package(url: "https://github.com/swift-libp2p/swift-libp2p.git", .upToNextMinor(from: "0.2.0")),
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.0.0")),
 
         // Testing

--- a/Sources/LibP2PWebSocket/LibP2PWebSocket.swift
+++ b/Sources/LibP2PWebSocket/LibP2PWebSocket.swift
@@ -93,7 +93,7 @@ public struct WebSocket: Transport {
                 channel: channel,
                 direction: .outbound,
                 remoteAddress: address,
-                expectedRemotePeer: try? PeerID(cid: address.getPeerID() ?? "")
+                expectedRemotePeer: try? address.getPeerID()
             )
 
             /// The connection installs the necessary channel handlers here


### PR DESCRIPTION
### What:
- Updated `getPeerID` to support the latest `Multiaddr` release
https://github.com/swift-libp2p/swift-multiaddr/releases/tag/0.1.0

### Why:
- https://github.com/swift-libp2p/swift-multiaddr/issues/14

### Breaking Changes
```swift
// From
Multiaddr.getPeerID() -> String?

// To
Multiaddr.getPeerID() throws -> PeerID
```